### PR TITLE
Fix case for import statements

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	webhooks "gopkg.in/go-playground/webhooks.v3"
 	receiver "gopkg.in/go-playground/webhooks.v3/github"
 
-	"github.com/autodesk/watchdog4git/watchdog"
+	"github.com/Autodesk/watchdog4git/watchdog"
 )
 
 const (

--- a/watchdog/watchdog.go
+++ b/watchdog/watchdog.go
@@ -21,7 +21,7 @@ import (
 	receiver "gopkg.in/go-playground/webhooks.v3/github"
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/autodesk/watchdog4git/attributes"
+	"github.com/Autodesk/watchdog4git/attributes"
 )
 
 const (


### PR DESCRIPTION
Running "go get github.com/Autodesk/watchdog4git"
in OSX results in errors: "case-insensitive import".
This will also affect Linux builds.

The proper organization name is spelled "Autodesk".